### PR TITLE
Add uftpd import to boot script with error handling

### DIFF
--- a/sys/boot.py
+++ b/sys/boot.py
@@ -28,6 +28,12 @@ gc.collect()
 
 sys.path.append('/user')
 
+try:
+    import uftpd
+except ImportError:
+    # if we fail to load this not a big deal
+    pass
+
 #touch = TouchPad(Pin(14))
 
 #if touch.read() > 500 :


### PR DESCRIPTION
The boot script has been updated to include an import statement for 'uftpd'. The import is enclosed within a try-except block to handle any ImportError that occurs, allowing the script to run without interruption if the import fails. This addition increases the script's resilience and reliability.